### PR TITLE
fix: Upgrade 4 vulnerable dependencies — 18 of 19 CVEs resolved

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,14 +27,14 @@ dependencies = [
     "psycopg2-binary>=2.9.9",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
-    "python-jose[cryptography]>=3.3.0",
+    "python-jose[cryptography]>=3.4.0",
     "passlib[bcrypt]>=1.7.4",
-    "python-multipart>=0.0.6",
-    "cryptography>=42.0.0",
+    "python-multipart>=0.0.22",
+    "cryptography>=46.0.5",
     "httpx>=0.26.0",
     # --- INTENTIONALLY VULNERABLE: requests 2.25.0 has known CVEs ---
     # This is planted for the sentrik vulns demo (CVE-2023-32681)
-    "requests==2.25.0",
+    "requests==2.33.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Ran `sentrik vulns --fix` to auto-patch vulnerable dependencies
- 4 packages upgraded in `pyproject.toml`
- 18 of 19 CVEs resolved (1 medium remaining in FastAPI — no version fix available yet)

## Dependency Upgrades

| Package | Before | After | CVEs Fixed |
|---------|--------|-------|------------|
| cryptography | 42.0.0 | 46.0.5 | 5 (1 high, 2 medium, 2 low) |
| python-jose | 3.3.0 | 3.4.0 | 3 (1 critical, 1 medium, 1 low) |
| python-multipart | 0.0.6 | 0.0.22 | 3 (3 high) |
| requests | 2.25.0 | 2.33.0 | 5 (1 medium, 4 low) |

## Supply Chain Status

| Metric | Before | After |
|--------|--------|-------|
| Total CVEs | 19 | **1** |
| Critical | 1 | **0** |
| High | 5 | **0** |
| Medium | 6 | **1** |
| Low | 7 | **0** |

## How this was done

```bash
sentrik vulns           # Scan for CVEs
sentrik vulns --fix     # Auto-patch pyproject.toml
sentrik vulns           # Verify fixes
```

## Additional supply chain checks

```bash
sentrik sbom            # 13 components catalogued (CycloneDX)
sentrik licenses        # All MIT/BSD/Apache — no copyleft risk
sentrik secrets         # 3 findings in src/config.py (pre-existing, tracked)
```

## Test plan

- [x] `sentrik vulns` — 1 remaining (medium, no fix available)
- [x] `sentrik licenses` — no copyleft violations
- [x] `sentrik gate` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)